### PR TITLE
Fixes issue where ServicePointManager.ServerCertificateValidationCallback has invalid params

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -297,20 +297,22 @@ namespace ModernHttpClient
                     goto sslErrorVerify;
                 }
 
+                var netCerts = Enumerable.Range(0, serverCertChain.Count)
+                    .Select(x => serverCertChain[x].ToX509Certificate2())
+                    .ToArray();
+
+                root = netCerts[0];
+
+                chain.Build(root);
+
                 if (serverCertChain.Count == 1) {
                     errors = SslPolicyErrors.RemoteCertificateChainErrors;
                     goto sslErrorVerify;
                 }
 
-                var netCerts = Enumerable.Range(0, serverCertChain.Count)
-                    .Select(x => serverCertChain[x].ToX509Certificate2())
-                    .ToArray();
-
                 for (int i = 1; i < netCerts.Length; i++) {
                     chain.ChainPolicy.ExtraStore.Add(netCerts[i]);
                 }
-
-                root = netCerts[0];
 
                 chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;


### PR DESCRIPTION
This fix is proposed as PR in original repository (paulcbetts/ModernHttpClient#180) almost 8 months ago, but there are still no any replies. I found the fix very useful. It will be nice if it could be applied to version of ModernHttpClient, which expected to be delivered with Xamarin.iOS 9.8.
